### PR TITLE
ci: minor improvements

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
         node-version: 14.x
         cache: 'npm'
         registry-url: https://npm.pkg.github.com/
-    - run: npm ci
+    - run: npm ci --ignore-scripts
       env:
         NODE_AUTH_TOKEN: ${{ secrets.PAT }}
     - run: npm test
@@ -33,7 +33,7 @@ jobs:
         node-version: 14.x
         cache: 'npm'
         registry-url: https://npm.pkg.github.com/
-    - run: npm ci
+    - run: npm ci --ignore-scripts
       env:
         NODE_AUTH_TOKEN: ${{ secrets.PAT }}
     - run: npm run prepare

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,12 @@
 name: CI
 
-on: [push]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   units:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,7 @@ jobs:
     - uses: actions/setup-node@v1
       with:
         node-version: 14.x
+        cache: 'npm'
         registry-url: https://npm.pkg.github.com/
     - run: npm ci
       env:
@@ -24,6 +25,7 @@ jobs:
     - uses: actions/setup-node@v1
       with:
         node-version: 14.x
+        cache: 'npm'
         registry-url: https://npm.pkg.github.com/
     - run: npm ci
       env:

--- a/.github/workflows/reuse.yaml
+++ b/.github/workflows/reuse.yaml
@@ -9,7 +9,7 @@ on:
       - master
 
 jobs:
-  test:
+  verify:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/reuse.yaml
+++ b/.github/workflows/reuse.yaml
@@ -1,6 +1,12 @@
 name: REUSE Compliance Check
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   test:


### PR DESCRIPTION
# Changes

- rename REUSE job to `REUSE Compliance Check / verify`
- avoid to execute `prepare` twice per job
- run workflows only on pushed to `master` or PRs that target to `master`
- cache NPM packages

