### PR TITLE
Add option to specify a github-token to avoid rate-limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![REUSE status](https://api.reuse.software/badge/github.com/SAP/project-piper-action)](https://api.reuse.software/info/github.com/SAP/project-piper-action)
 
+:construction: The master branch is soon to be deprecated. The main branch will become the default branch.
+
 Continuous delivery is a method to develop software with short feedback cycles.
 It is applicable to projects both for SAP Cloud Platform and SAP on-premise platforms.
 SAP implements tooling for continuous delivery in [project "Piper"](https://sap.github.io/jenkins-library/).

--- a/action.yml
+++ b/action.yml
@@ -13,9 +13,13 @@ inputs:
     description: 'specify a version of the piper binary to use, may be "master", "latest" or a released tag'
     required: false
     default: 'latest'
+  github-token:
+    description: 'specify a token for access to github.com. This may be required when running on GitHub Enterprise to avoid rate-limits'
+    required: false
+    default: ''
 runs:
   using: 'node16'
   main: 'dist/index.js'
 branding:
-  icon: 'play'  
+  icon: 'play'
   color: 'green'

--- a/src/piper.js
+++ b/src/piper.js
@@ -8,15 +8,18 @@ async function run () {
     const command = core.getInput('command')
     const flags = core.getInput('flags')
     const version = core.getInput('piper-version')
-
+    const auth = core.getInput('github-token')
     // Download Piper
     const piperBin = 'piper'
-    await new utils.GithubDownloaderBuilder('sap',
+    const downloader = new utils.GithubDownloaderBuilder('sap',
       'jenkins-library',
       piperBin,
       version)
       .githubEndpoint('https://github.com')
-      .download()
+    if (auth) {
+      downloader._auth = `Bearer ${auth}`
+    }
+    await downloader.download()
 
     const directoryRestore = new utils.DirectoryRestore('.pipeline/commonPipelineEnvironment')
     if (enableBetaFeatures) {


### PR DESCRIPTION
Hi, 
I hope it is okay for me to just open a pull request with a proposal. I'm running this action on a GitHub Enterprise machine. The problem that I'm facing is that ~50% of the times the request to check for the latest version of Piper gets rejected by GitHub due to rate-limiting. I found that if I authenticate to github.com I could work around this rate-limit and not run into the issue.