### PR TITLE
Add platform dependant suffix to the available piper binaries

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs'
+import * as os from 'os'
 import { join } from 'path'
 import { chdir, cwd } from 'process'
 import { Octokit } from '@octokit/core'

--- a/src/github.ts
+++ b/src/github.ts
@@ -1,5 +1,4 @@
 import * as fs from 'fs'
-import * as os from 'os'
 import { join } from 'path'
 import { chdir, cwd } from 'process'
 import { Octokit } from '@octokit/core'
@@ -162,13 +161,29 @@ async function getPiperDownloadURL (piper: string, version?: string): Promise<st
 }
 
 async function getPiperBinaryNameFromInputs (isEnterpriseStep: boolean, version?: string): Promise<string> {
-  let piper = 'piper'
+  let piper = 'piper'  
   if (isEnterpriseStep) {
     piper = 'sap-piper'
-  }
+  }  
   if (version === 'master') {
     piper += '_master'
   }
+  // Determine the running platform - only the available precompiled binaries in GitHub
+  switch (process.platform) {
+    case 'linux', 'freebsd', 'openbsd':
+      // Default Piper executable. Do nothing - for reference only
+      break
+    case 'darwin':
+      if (process.arch === 'arm64')
+        piper += '-darwin.arm64'
+      if (process.arch === 'x64' || process.arch === 'ia32')
+        piper += '-darwin.x86_64'
+      break
+    case 'win32':
+      // Windows binary not available yet
+      break      
+  }
+  
   return piper
 }
 


### PR DESCRIPTION
Extend getPiperBinaryNameFromInputs by adding platform dependant suffix to the available precompiled piper binaries on GitHub